### PR TITLE
Wait for MathJax startup before typesetting

### DIFF
--- a/docs/_static/mathjax.js
+++ b/docs/_static/mathjax.js
@@ -15,9 +15,11 @@ window.MathJax = {
     }
   };
   
-  document$.subscribe(() => { 
-    MathJax.startup.output.clearCache()
-    MathJax.typesetClear()
-    MathJax.texReset()
-    MathJax.typesetPromise()
+  document$.subscribe(() => {
+    MathJax.startup.promise.then(() => {
+      MathJax.startup.output.clearCache()
+      MathJax.typesetClear()
+      MathJax.texReset()
+      MathJax.typesetPromise()
+    })
   })


### PR DESCRIPTION
  ## Summary

  Wait for MathJax startup to complete before clearing cached output and
  typesetting formulas during Material instant navigation.

  ## Root Cause

  On a slow network, `document$` can emit before the MathJax CDN script has
  finished initialization. At that point, `MathJax.startup.output` is still
  `null`, causing `clearCache()` to fail and leaving formulas blank until the
  page is refreshed.