### PR TITLE
Add grouped flux fitting and Fisher utilities

### DIFF
--- a/src/microlux/__init__.py
+++ b/src/microlux/__init__.py
@@ -12,6 +12,16 @@ all = [
     "TrajectoryModel",
     "TrajectoryParameters",
     "get_trajectory_model",
+    "FisherInformation",
+    "FisherResult",
+    "GroupedFluxFit",
+    "fisher_information",
+    "fisher_from_residuals",
+    "normalized_residuals",
+    "fit_grouped_fluxes",
+    "profiled_grouped_fluxes",
+    "profiled_grouped_residuals",
+    "profiled_grouped_fisher",
 ]
 
 from .basic_function import (
@@ -20,6 +30,18 @@ from .basic_function import (
 )
 from .coordinates import Coordinates as Coordinates
 from .countour import contour_integral as contour_integral
+from .fitting import (
+    fisher_from_residuals as fisher_from_residuals,
+    fisher_information as fisher_information,
+    FisherInformation as FisherInformation,
+    FisherResult as FisherResult,
+    fit_grouped_fluxes as fit_grouped_fluxes,
+    GroupedFluxFit as GroupedFluxFit,
+    normalized_residuals as normalized_residuals,
+    profiled_grouped_fisher as profiled_grouped_fisher,
+    profiled_grouped_fluxes as profiled_grouped_fluxes,
+    profiled_grouped_residuals as profiled_grouped_residuals,
+)
 from .model import (
     binary_mag as binary_mag,
     extended_light_curve as extended_light_curve,

--- a/src/microlux/fitting.py
+++ b/src/microlux/fitting.py
@@ -1,0 +1,275 @@
+"""Differentiable residual, linear-flux, and Fisher utilities."""
+
+from typing import Callable, NamedTuple, Optional
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+
+class FisherInformation(NamedTuple):
+    """JAX-compatible residual Jacobian and Fisher matrix."""
+
+    jacobian: jax.Array
+    fisher_matrix: jax.Array
+
+
+class FisherResult(NamedTuple):
+    """Eager Fisher result with covariance and reliability diagnostics."""
+
+    jacobian: np.ndarray
+    fisher_matrix: np.ndarray
+    covariance: np.ndarray
+    errors: np.ndarray
+    correlation: np.ndarray
+    rank: int
+    condition_number: float
+
+
+class GroupedFluxFit(NamedTuple):
+    """Analytic source/blend-flux fit for independent photometric groups."""
+
+    source_flux: jax.Array
+    blend_flux: jax.Array
+    covariance: jax.Array
+    model_flux: jax.Array
+    residuals: jax.Array
+    chi2_by_group: jax.Array
+
+
+def fisher_information(
+    residual_fn: Callable[[jax.Array], jax.Array], params: jax.Array
+) -> FisherInformation:
+    """Return the residual Jacobian and Gauss--Newton Fisher matrix."""
+    jacobian = jax.jacfwd(residual_fn)(params)
+    if jacobian.ndim != 2:
+        raise ValueError("params and normalized residuals must be one-dimensional.")
+    fisher_matrix = jacobian.T @ jacobian
+    return FisherInformation(jacobian, fisher_matrix)
+
+
+def fisher_from_residuals(
+    residual_fn: Callable[[jax.Array], jax.Array], params: jax.Array
+) -> FisherResult:
+    """Compute an eager, validated Fisher covariance from normalized residuals."""
+    information = fisher_information(residual_fn, params)
+    jacobian = np.asarray(information.jacobian)
+    fisher_matrix = np.asarray(information.fisher_matrix)
+
+    if not np.all(np.isfinite(jacobian)) or not np.all(np.isfinite(fisher_matrix)):
+        raise ValueError("Fisher calculation produced non-finite values.")
+
+    rank = int(np.linalg.matrix_rank(fisher_matrix))
+    condition_number = float(np.linalg.cond(fisher_matrix))
+    if rank < fisher_matrix.shape[0]:
+        raise np.linalg.LinAlgError("Fisher matrix is singular.")
+
+    covariance = np.linalg.inv(fisher_matrix)
+    if not np.all(np.isfinite(covariance)):
+        raise ValueError("Fisher covariance contains non-finite values.")
+
+    variance = np.diag(covariance)
+    if np.any(variance < 0):
+        raise ValueError("Fisher covariance has a negative diagonal entry.")
+
+    errors = np.sqrt(variance)
+    correlation = covariance / np.outer(errors, errors)
+    return FisherResult(
+        jacobian=jacobian,
+        fisher_matrix=fisher_matrix,
+        covariance=covariance,
+        errors=errors,
+        correlation=correlation,
+        rank=rank,
+        condition_number=condition_number,
+    )
+
+
+def normalized_residuals(
+    params: jax.Array,
+    times: jax.Array,
+    flux: jax.Array,
+    flux_err: jax.Array,
+    model_fn: Callable[[jax.Array, jax.Array], jax.Array],
+) -> jax.Array:
+    """Return Gaussian residuals normalized by their flux uncertainties."""
+    model_flux = model_fn(params, times)
+    return (flux - model_flux) / flux_err
+
+
+def _validate_grouped_inputs(
+    magnification,
+    flux,
+    flux_err,
+    group_ids,
+    n_groups: Optional[int],
+) -> int:
+    """Validate eager grouped-fit inputs and return the group count."""
+    arrays = tuple(
+        np.asarray(values) for values in (magnification, flux, flux_err, group_ids)
+    )
+    if any(values.ndim != 1 for values in arrays):
+        raise ValueError("Grouped flux fitting requires one-dimensional arrays.")
+    if len(arrays[0]) == 0:
+        raise ValueError("Grouped flux fitting requires non-empty arrays.")
+    if any(values.shape != arrays[0].shape for values in arrays[1:]):
+        raise ValueError("Grouped flux fitting inputs must have the same shape.")
+    if not all(np.all(np.isfinite(values)) for values in arrays[:3]):
+        raise ValueError("Grouped flux fitting inputs must be finite.")
+    if np.any(arrays[2] <= 0):
+        raise ValueError("Flux uncertainties must be positive.")
+    if not np.issubdtype(arrays[3].dtype, np.integer):
+        raise ValueError("group_ids must contain integers.")
+
+    unique_groups = np.unique(arrays[3])
+    inferred_groups = len(unique_groups)
+    if n_groups is None:
+        n_groups = inferred_groups
+    if n_groups < 1 or not np.array_equal(unique_groups, np.arange(n_groups)):
+        raise ValueError("group_ids must be contiguous from 0 to n_groups - 1.")
+
+    for group_id in range(n_groups):
+        mask = arrays[3] == group_id
+        design = np.column_stack([arrays[0][mask], np.ones(np.sum(mask))])
+        if np.linalg.matrix_rank(design) < 2:
+            raise np.linalg.LinAlgError(
+                f"Source/blend flux design is singular for group {group_id}."
+            )
+    return n_groups
+
+
+def _fit_grouped_fluxes(
+    magnification: jax.Array,
+    flux: jax.Array,
+    flux_err: jax.Array,
+    group_ids: jax.Array,
+    n_groups: int,
+) -> GroupedFluxFit:
+    """Solve all grouped source/blend flux fits with JAX segment sums."""
+    magnification = jnp.asarray(magnification)
+    flux = jnp.asarray(flux)
+    flux_err = jnp.asarray(flux_err)
+    group_ids = jnp.asarray(group_ids)
+    weight = 1.0 / flux_err**2
+
+    def grouped_sum(values):
+        """Sum per-observation values within each photometric group."""
+        return jax.ops.segment_sum(values, group_ids, num_segments=n_groups)
+
+    sum_aa = grouped_sum(weight * magnification**2)
+    sum_a = grouped_sum(weight * magnification)
+    sum_one = grouped_sum(weight)
+    sum_ay = grouped_sum(weight * magnification * flux)
+    sum_y = grouped_sum(weight * flux)
+    determinant = sum_aa * sum_one - sum_a**2
+
+    source_flux = (sum_ay * sum_one - sum_y * sum_a) / determinant
+    blend_flux = (sum_aa * sum_y - sum_a * sum_ay) / determinant
+    covariance = (
+        jnp.stack(
+            [
+                jnp.stack([sum_one, -sum_a], axis=-1),
+                jnp.stack([-sum_a, sum_aa], axis=-1),
+            ],
+            axis=-2,
+        )
+        / determinant[:, None, None]
+    )
+
+    model_flux = source_flux[group_ids] * magnification + blend_flux[group_ids]
+    residuals = (flux - model_flux) / flux_err
+    chi2_by_group = grouped_sum(residuals**2)
+    return GroupedFluxFit(
+        source_flux=source_flux,
+        blend_flux=blend_flux,
+        covariance=covariance,
+        model_flux=model_flux,
+        residuals=residuals,
+        chi2_by_group=chi2_by_group,
+    )
+
+
+def fit_grouped_fluxes(
+    magnification,
+    flux,
+    flux_err,
+    group_ids,
+    *,
+    n_groups: Optional[int] = None,
+) -> GroupedFluxFit:
+    """Fit independent source and blend fluxes for contiguous groups."""
+    n_groups = _validate_grouped_inputs(
+        magnification, flux, flux_err, group_ids, n_groups
+    )
+    result = _fit_grouped_fluxes(magnification, flux, flux_err, group_ids, n_groups)
+    if not all(np.all(np.isfinite(np.asarray(values))) for values in result):
+        raise ValueError("Grouped flux fitting produced non-finite values.")
+    return result
+
+
+def profiled_grouped_fluxes(
+    params: jax.Array,
+    times: jax.Array,
+    flux: jax.Array,
+    flux_err: jax.Array,
+    group_ids: jax.Array,
+    magnification_fn: Callable[[jax.Array, jax.Array], jax.Array],
+    *,
+    n_groups: int,
+) -> GroupedFluxFit:
+    """Return a differentiable per-group source and blend flux fit."""
+    magnification = magnification_fn(params, times)
+    return _fit_grouped_fluxes(magnification, flux, flux_err, group_ids, n_groups)
+
+
+def profiled_grouped_residuals(
+    params: jax.Array,
+    times: jax.Array,
+    flux: jax.Array,
+    flux_err: jax.Array,
+    group_ids: jax.Array,
+    magnification_fn: Callable[[jax.Array, jax.Array], jax.Array],
+    *,
+    n_groups: int,
+) -> jax.Array:
+    """Return residuals after profiling per-group source and blend fluxes."""
+    return profiled_grouped_fluxes(
+        params,
+        times,
+        flux,
+        flux_err,
+        group_ids,
+        magnification_fn,
+        n_groups=n_groups,
+    ).residuals
+
+
+def profiled_grouped_fisher(
+    params: jax.Array,
+    times: jax.Array,
+    flux: jax.Array,
+    flux_err: jax.Array,
+    group_ids: jax.Array,
+    magnification_fn: Callable[[jax.Array, jax.Array], jax.Array],
+    *,
+    n_groups: Optional[int] = None,
+) -> FisherResult:
+    """Compute a validated Fisher result with per-group fluxes profiled out."""
+    magnification = magnification_fn(params, times)
+    n_groups = _validate_grouped_inputs(
+        magnification, flux, flux_err, group_ids, n_groups
+    )
+
+    def residual_fn(values):
+        """Evaluate normalized residuals after profiling grouped fluxes."""
+        return profiled_grouped_residuals(
+            values,
+            times,
+            flux,
+            flux_err,
+            group_ids,
+            magnification_fn,
+            n_groups=n_groups,
+        )
+
+    return fisher_from_residuals(residual_fn, params)

--- a/test/test_fitting.py
+++ b/test/test_fitting.py
@@ -1,0 +1,210 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from microlux.fitting import (
+    fisher_from_residuals,
+    fisher_information,
+    fit_grouped_fluxes,
+    normalized_residuals,
+    profiled_grouped_fisher,
+    profiled_grouped_fluxes,
+    profiled_grouped_residuals,
+)
+
+
+@pytest.mark.fast
+def test_fisher_from_linear_residuals():
+    design = jnp.array(
+        [
+            [1.0, 0.0],
+            [0.0, 2.0],
+            [1.0, 1.0],
+        ]
+    )
+    offset = jnp.array([0.2, -0.3, 0.5])
+
+    def residual_fn(params):
+        return design @ params - offset
+
+    result = fisher_from_residuals(residual_fn, jnp.array([0.1, -0.2]))
+    expected_fisher = np.asarray(design.T @ design)
+    expected_covariance = np.linalg.inv(expected_fisher)
+
+    np.testing.assert_allclose(result.jacobian, design)
+    np.testing.assert_allclose(result.fisher_matrix, expected_fisher)
+    np.testing.assert_allclose(result.covariance, expected_covariance)
+    np.testing.assert_allclose(result.errors, np.sqrt(np.diag(expected_covariance)))
+    np.testing.assert_allclose(np.diag(result.correlation), 1.0)
+    assert result.rank == 2
+    assert np.isclose(result.condition_number, np.linalg.cond(expected_fisher))
+
+
+@pytest.mark.fast
+def test_fisher_information_can_be_jitted():
+    design = jnp.array([[1.0, 2.0], [3.0, 4.0], [5.0, 7.0]])
+    residual_fn = lambda params: design @ params
+    jacobian, fisher_matrix = jax.jit(
+        lambda params: fisher_information(residual_fn, params)
+    )(jnp.array([0.2, -0.1]))
+
+    np.testing.assert_allclose(jacobian, design)
+    np.testing.assert_allclose(fisher_matrix, design.T @ design)
+
+
+@pytest.mark.fast
+def test_fisher_from_residuals_rejects_singular_matrix():
+    def residual_fn(params):
+        return jnp.array([params[0] + params[1], 2.0 * (params[0] + params[1])])
+
+    with pytest.raises(np.linalg.LinAlgError, match="singular"):
+        fisher_from_residuals(residual_fn, jnp.array([1.0, 2.0]))
+
+
+@pytest.mark.fast
+def test_fisher_from_residuals_rejects_nonfinite_values():
+    def residual_fn(params):
+        return jnp.array([params[0], jnp.nan * params[1]])
+
+    with pytest.raises(ValueError, match="non-finite"):
+        fisher_from_residuals(residual_fn, jnp.array([1.0, 2.0]))
+
+
+@pytest.mark.fast
+def test_normalized_residuals_uses_flux_model():
+    times = jnp.array([0.0, 1.0, 2.0])
+    flux = jnp.array([1.2, 2.9, 5.1])
+    flux_err = jnp.array([0.1, 0.2, 0.5])
+    model_fn = lambda params, model_times: params[0] * model_times + params[1]
+
+    residuals = normalized_residuals(
+        jnp.array([2.0, 1.0]), times, flux, flux_err, model_fn
+    )
+
+    np.testing.assert_allclose(residuals, [2.0, -0.5, 0.2])
+
+
+@pytest.mark.fast
+def test_fit_grouped_fluxes_matches_weighted_least_squares():
+    magnification = np.array([1.0, 1.8, 2.7, 1.2, 2.2, 3.1])
+    group_ids = np.array([0, 0, 0, 1, 1, 1])
+    flux_err = np.array([0.1, 0.2, 0.15, 0.3, 0.2, 0.25])
+    source_flux = np.array([2.0, 3.5])
+    blend_flux = np.array([0.4, -0.7])
+    noise = np.array([0.01, -0.03, 0.02, -0.04, 0.05, -0.01])
+    flux = source_flux[group_ids] * magnification + blend_flux[group_ids] + noise
+
+    result = fit_grouped_fluxes(magnification, flux, flux_err, group_ids)
+
+    for group_id in range(2):
+        mask = group_ids == group_id
+        design = np.column_stack([magnification[mask], np.ones(np.sum(mask))])
+        weighted_design = design / flux_err[mask, None]
+        weighted_flux = flux[mask] / flux_err[mask]
+        expected_coefficients = np.linalg.solve(
+            weighted_design.T @ weighted_design,
+            weighted_design.T @ weighted_flux,
+        )
+        expected_covariance = np.linalg.inv(weighted_design.T @ weighted_design)
+        np.testing.assert_allclose(
+            [result.source_flux[group_id], result.blend_flux[group_id]],
+            expected_coefficients,
+        )
+        np.testing.assert_allclose(result.covariance[group_id], expected_covariance)
+
+    np.testing.assert_allclose(
+        result.model_flux,
+        result.source_flux[group_ids] * magnification + result.blend_flux[group_ids],
+    )
+    np.testing.assert_allclose(
+        result.chi2_by_group,
+        [
+            np.sum(np.asarray(result.residuals)[group_ids == group_id] ** 2)
+            for group_id in range(2)
+        ],
+    )
+
+
+@pytest.mark.fast
+def test_fit_grouped_fluxes_rejects_noncontiguous_groups():
+    with pytest.raises(ValueError, match="contiguous"):
+        fit_grouped_fluxes(
+            np.array([1.0, 2.0, 1.0, 2.0]),
+            np.array([1.0, 2.0, 1.0, 2.0]),
+            np.ones(4),
+            np.array([0, 0, 2, 2]),
+        )
+
+
+@pytest.mark.fast
+def test_profiled_grouped_residual_jacobian_matches_finite_difference():
+    times = jnp.linspace(-1.5, 1.5, 10)
+    group_ids = jnp.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
+    flux_err = jnp.linspace(0.08, 0.16, 10)
+
+    def magnification_fn(params, model_times):
+        return (
+            1.5
+            + jnp.exp(params[0] * model_times)
+            + params[1] * jnp.sin(2.0 * model_times)
+        )
+
+    injected_params = jnp.array([0.25, 0.12])
+    magnification = magnification_fn(injected_params, times)
+    source_flux = jnp.array([2.0, 3.0])
+    blend_flux = jnp.array([0.5, -0.4])
+    noise = jnp.array([0.01, -0.02, 0.03, -0.01, 0.02, -0.03, 0.01, 0.02, -0.02, 0.01])
+    flux = source_flux[group_ids] * magnification + blend_flux[group_ids] + noise
+    params = jnp.array([0.22, 0.1])
+
+    def residual_fn(values):
+        return profiled_grouped_residuals(
+            values,
+            times,
+            flux,
+            flux_err,
+            group_ids,
+            magnification_fn,
+            n_groups=2,
+        )
+
+    profiled_fit = jax.jit(
+        lambda values: profiled_grouped_fluxes(
+            values,
+            times,
+            flux,
+            flux_err,
+            group_ids,
+            magnification_fn,
+            n_groups=2,
+        )
+    )(params)
+    np.testing.assert_allclose(profiled_fit.residuals, residual_fn(params))
+    assert profiled_fit.source_flux.shape == (2,)
+    assert profiled_fit.blend_flux.shape == (2,)
+
+    jacobian = np.asarray(jax.jacfwd(residual_fn)(params))
+    epsilon = 1e-5
+    finite_difference = np.column_stack(
+        [
+            (
+                np.asarray(residual_fn(params.at[index].add(epsilon)))
+                - np.asarray(residual_fn(params.at[index].add(-epsilon)))
+            )
+            / (2.0 * epsilon)
+            for index in range(2)
+        ]
+    )
+
+    np.testing.assert_allclose(jacobian, finite_difference, rtol=2e-5, atol=2e-6)
+    np.testing.assert_allclose(jax.jit(residual_fn)(params), residual_fn(params))
+
+    fisher_result = profiled_grouped_fisher(
+        params,
+        times,
+        flux,
+        flux_err,
+        group_ids,
+        magnification_fn,
+    )
+    np.testing.assert_allclose(fisher_result.jacobian, jacobian)


### PR DESCRIPTION
## Summary

Add JAX-compatible utilities for Fisher analysis and analytic source/blend flux fitting.

## Changes

- Compute residual Jacobians, Fisher matrices, covariance, errors, and correlations.
- Analytically fit source and blend fluxes for multiple photometric datasets.
- Profile flux parameters while preserving JIT compilation and automatic differentiation.
- Validate singular matrices and invalid grouped inputs.
- Export the new fitting APIs from `microlux`.

## Tests

- Compared grouped flux fitting with weighted least squares.
- Compared profiled Jacobians with finite differences.
- Verified JIT compatibility and error handling.

`8 passed`