### PR TITLE
Improve numerical robustness in root initialization

### DIFF
--- a/src/microlux/countour.py
+++ b/src/microlux/countour.py
@@ -274,7 +274,9 @@ def contour_integral(
 
 
 @partial(jax.jit, static_argnames=("inite", "n_ite"))
-def contour_init(rho, s, q, trajectory_l, epsilon, epsilon_rel=0, inite=30, n_ite=60):
+def contour_init(
+    rho, s, q, trajectory_l, epsilon, epsilon_rel=1e-3, inite=30, n_ite=60
+):
     """
     Perform initial contour integration with a fixed array length.
 
@@ -284,7 +286,7 @@ def contour_init(rho, s, q, trajectory_l, epsilon, epsilon_rel=0, inite=30, n_it
         q (float): The mass ratio of the two lens components.
         trajectory_l (array): The trajectory of the lens in the low mass coordinate system.
         epsilon (float): The integration precision.
-        epsilon_rel (float, optional): The relative integration precision. Defaults to 0.
+        epsilon_rel (float, optional): The relative integration precision. Defaults to 1e-3.
         inite (int, optional): The number of initial integration points. Defaults to 30.
         n_ite (int, optional): The total number of integration points. Defaults to 60.
 

--- a/src/microlux/polynomial_solver.py
+++ b/src/microlux/polynomial_solver.py
@@ -215,8 +215,12 @@ def AE_roots0(coff: jnp.ndarray) -> jnp.ndarray:
     """
 
     def UV(coff):
-        U = 1 + 1 / jnp.abs(coff[0]) * jnp.max(jnp.abs(coff[:-1]))
-        V = jnp.abs(coff[-1]) / (jnp.abs(coff[-1]) + jnp.max(jnp.abs(coff[:-1])))
+        scale = jnp.max(jnp.abs(coff[:-1]))
+        leading_coff = jnp.maximum(
+            jnp.abs(coff[0]), jnp.sqrt(jnp.finfo(coff.real.dtype).eps) * scale
+        )
+        U = 1 + scale / leading_coff
+        V = jnp.abs(coff[-1]) / (jnp.abs(coff[-1]) + scale)
         return U, V
 
     def Roots0(coff):

--- a/test/test_polynomial_solver.py
+++ b/test/test_polynomial_solver.py
@@ -4,7 +4,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from microlux.basic_function import get_poly_coff, to_lowmass
+from microlux.basic_function import get_poly_coff, to_lowmass, verify
 from microlux.polynomial_solver import Aberth_Ehrlich, AE_roots0
 from test_util import get_caustic_permutation
 
@@ -12,6 +12,23 @@ from test_util import get_caustic_permutation
 rho_values = [1e-2, 1e-3, 1e-4]
 q_values = [1e-1, 1e-2, 1e-3]
 s_values = [0.6, 1.0, 1.4]
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("lens_position", [0.0, 0.9], ids=["secondary", "primary"])
+def test_polynomial_near_lens_cold_start(lens_position):
+    q = 0.2
+    s = 0.9
+    m1 = 1 / (1 + q)
+    m2 = q / (1 + q)
+    offset = 1e-14 * (1 + 1j) / jnp.sqrt(2)
+    zeta_l = jnp.array([[lens_position + offset]])
+    coff = get_poly_coff(zeta_l, s, m2)[0]
+
+    roots = Aberth_Ehrlich(coff, AE_roots0(coff), MAX_ITER=50)
+    lens_errors = jnp.sort(verify(zeta_l, roots[None, :], s, m1, m2)[0])
+
+    assert lens_errors[2] < 1e-10
 
 
 @pytest.mark.fast


### PR DESCRIPTION
  ## Summary

  Improve numerical stability in the polynomial solver and contour initialization.

  ## Changes

  - Limit the initial Aberth root-search range when the leading polynomial coefficient is very small.
  - Add regression coverage for cold starts near both lens positions.
  - Change the default relative contour tolerance from zero to `1e-3` to avoid division by zero in adaptive point insertion.

  ## Tests

  - Polynomial solver tests: `47 passed`
  - Ruff and pre-commit checks passed.