### PR TITLE
Batch contour array updates

### DIFF
--- a/src/microlux/countour.py
+++ b/src/microlux/countour.py
@@ -20,7 +20,6 @@ from .solution import (
 )
 from .utils import (
     Error_State,
-    insert_body,
     Iterative_State,
     stop_grad_wrapper,
     warn_length_not_enough,
@@ -28,6 +27,31 @@ from .utils import (
 
 
 jax.config.update("jax_enable_x64", True)
+
+
+def build_add_theta(theta, idx, add_number, max_add, max_total_num):
+    """Build packed theta values for all selected intervals at once."""
+    add_number = add_number.reshape(-1)
+    valid_idx = idx >= 0
+    safe_idx = jnp.where(valid_idx, idx, 1)
+    local_index = jnp.arange(1, max_add + 1)[None, :]
+
+    theta_left = theta[safe_idx - 1, 0][:, None]
+    theta_right = theta[safe_idx, 0][:, None]
+    candidate_theta = theta_left + local_index * (theta_right - theta_left) / (
+        add_number[:, None] + 1
+    )
+    valid = valid_idx[:, None] & (local_index <= add_number[:, None])
+    selected = jnp.where(valid.reshape(-1), size=max_total_num, fill_value=-1)[0]
+    safe_selected = jnp.where(selected >= 0, selected, 0)
+
+    add_theta = candidate_theta.reshape(-1)[safe_selected]
+    add_theta = jnp.where(selected >= 0, add_theta, jnp.nan)[:, None]
+
+    candidate_idx = jnp.broadcast_to(idx[:, None], candidate_theta.shape)
+    add_idx = candidate_idx.reshape(-1)[safe_selected]
+    add_idx = jnp.where(selected >= 0, add_idx, -1)
+    return add_theta, add_idx
 
 
 def anayltic_warpper(trajectory_l, rho, s, q, roots_State, mag_State):
@@ -461,43 +485,14 @@ def while_body_fun(carry):
     )
     # jax.debug.print('add_number {}/{}  idx length {}/{}  sample_n: {}',add_number.sum(),Max_total_num,(idx!=0).sum(),Max_index_length,sample_n[0])
 
-    def theta_encode(carry, k):
-        (theta, idx, add_number, add_theta_encode) = carry
-
-        theta_diff = (theta[idx[k]] - theta[idx[k] - 1]) / (add_number[k] + 1)
-        add_theta = (
-            jnp.arange(1, Max_total_num + 1)[:, None] * theta_diff + theta[idx[k] - 1]
-        )
-        add_theta = jnp.where(
-            (jnp.arange(Max_total_num) < add_number[k])[:, None], add_theta, jnp.nan
-        )
-        carry2, _ = insert_body(
-            (
-                add_theta_encode,
-                add_theta,
-                jnp.where(jnp.isnan(add_theta_encode), size=1)[0],
-                add_number[k][None],
-            ),
-            0,
-        )
-        add_theta_encode = carry2[0]
-        return (theta, idx, add_number, add_theta_encode), k
-
     def update_carry(carrylast):
-        carry, _ = lax.scan(
-            theta_encode,
-            (theta, idx, add_number, jnp.full((Max_total_num, 1), jnp.nan)),
-            jnp.arange(idx.shape[0]),
+        add_theta, idx_all = build_add_theta(
+            theta,
+            idx,
+            add_number,
+            max_add=Max_add,
+            max_total_num=Max_total_num,
         )
-        add_theta = carry[-1]
-        jax_repeat = jax.jit(
-            jnp.repeat, static_argnames=["axis", "total_repeat_length"]
-        )
-        idx_all = jax_repeat(idx, add_number, total_repeat_length=Max_total_num)
-        idx_all = jnp.where(
-            jnp.arange(idx_all.shape[0]) < add_number.sum(), idx_all, -1
-        )
-        ####
         add_zeta_l = get_zeta_l(rho, trajectory_l, add_theta)
         roots_State_new, buried_error, add_outloop = add_points(
             idx_all, add_zeta_l, add_theta, roots_State, s, 1 / (1 + q), q / (1 + q)

--- a/src/microlux/solution.py
+++ b/src/microlux/solution.py
@@ -8,8 +8,10 @@ from .basic_function import get_parity, get_parity_error, get_poly_coff, verify
 from .linear_sum_assignment import find_nearest
 from .polynomial_solver import get_roots
 from .utils import (
-    custom_delete,
-    custom_insert,
+    apply_insert,
+    compact_delete,
+    get_delete_source_indices,
+    get_insert_source_indices,
     Iterative_State,
     MAX_CAUSTIC_INTERSECT_NUM,
 )
@@ -41,7 +43,8 @@ def add_points(add_idx, add_zeta, add_theta, roots_State, s, m1, m2):
     sample_n += (add_idx != -1).sum()
 
     ## insert the new samplings
-    insert_fun = lambda x, y: custom_insert(x, add_idx, y)
+    source_indices = get_insert_source_indices(theta.shape[0], add_idx)
+    insert_fun = lambda x, y: apply_insert(x, y, source_indices)
     original_list = [theta, roots, parity, ghost_roots_dis, sort_flag]
     add_list = [
         add_theta,
@@ -486,8 +489,9 @@ def theta_remove_fun(carry):
     sample_n -= cond.sum()
 
     delete_tree = [theta, real_parity, real_roots, ghost_roots_dis, add_idx[:, None]]
+    source_indices = get_delete_source_indices(n_ite, delidx)
     theta, real_parity, real_roots, ghost_roots_dis, add_idx = jax.tree.map(
-        lambda x: custom_delete(x, delidx), delete_tree
+        lambda x: compact_delete(x, source_indices), delete_tree
     )
     add_idx = add_idx[:, 0]
 

--- a/src/microlux/utils.py
+++ b/src/microlux/utils.py
@@ -97,6 +97,35 @@ def custom_insert(array, idx, add_array):
     return final_array
 
 
+def get_insert_source_indices(array_length, add_idx):
+    """Build source indices for inserting a packed array in one gather."""
+    add_idx = jnp.asarray(add_idx)
+    valid = add_idx >= 0
+    safe_idx = jnp.where(valid, add_idx, 0)
+    insert_count = jnp.zeros(array_length, dtype=add_idx.dtype)
+    insert_count = insert_count.at[safe_idx].add(valid.astype(add_idx.dtype))
+
+    old_position = jnp.arange(array_length) + jnp.cumsum(insert_count)
+    add_rank = jnp.cumsum(valid.astype(add_idx.dtype)) - 1
+    add_position = jnp.where(valid, add_idx + add_rank, array_length)
+
+    padding_index = array_length + add_idx.shape[0]
+    source_indices = jnp.full(array_length, padding_index, dtype=add_idx.dtype)
+    source_indices = source_indices.at[old_position].set(
+        jnp.arange(array_length), mode="drop"
+    )
+    source_indices = source_indices.at[add_position].set(
+        array_length + jnp.arange(add_idx.shape[0]), mode="drop"
+    )
+    return source_indices
+
+
+def apply_insert(array, add_array, source_indices):
+    """Apply precomputed insertion indices to one padded array."""
+    combined = jnp.concatenate([array, add_array, array[-1:]], axis=0)
+    return combined[source_indices]
+
+
 def delete_body(carry, k):
     array, ite2, delidx = carry
     mask = ite2 < delidx[k]
@@ -117,6 +146,22 @@ def custom_delete(array, delidx):
         (ite < ite.size - (delidx < array.shape[0]).sum())[:, None], array, fill_value
     )
     return array
+
+
+def get_delete_source_indices(array_length, delidx):
+    """Build source indices for deleting packed rows in one gather."""
+    delidx = jnp.asarray(delidx)
+    valid = (delidx >= 0) & (delidx < array_length)
+    safe_idx = jnp.where(valid, delidx, 0)
+    delete_count = jnp.zeros(array_length, dtype=delidx.dtype)
+    delete_count = delete_count.at[safe_idx].add(valid.astype(delidx.dtype))
+    return jnp.where(delete_count == 0, size=array_length, fill_value=array_length)[0]
+
+
+def compact_delete(array, source_indices):
+    """Apply precomputed deletion indices to one padded array."""
+    padded = jnp.concatenate([array, array[-1:]], axis=0)
+    return padded[source_indices]
 
 
 def stop_grad_wrapper(func):

--- a/test/test_contour_array_ops.py
+++ b/test/test_contour_array_ops.py
@@ -1,0 +1,99 @@
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from microlux.countour import build_add_theta
+from microlux.utils import (
+    apply_insert,
+    compact_delete,
+    custom_delete,
+    custom_insert,
+    get_delete_source_indices,
+    get_insert_source_indices,
+)
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "add_idx",
+    [
+        [2, -1, -1],
+        [2, 2, -1],
+        [1, 1, 5, -1],
+        [3, 6, 6, 9],
+        [10, -1],
+    ],
+)
+def test_batch_insert_matches_custom_insert(add_idx):
+    array = jnp.arange(60, dtype=float).reshape(12, 5)
+    add_array = 100 + jnp.arange(5 * len(add_idx), dtype=float).reshape(-1, 5)
+    add_idx = jnp.asarray(add_idx)
+
+    source_indices = get_insert_source_indices(array.shape[0], add_idx)
+    result = apply_insert(array, add_array, source_indices)
+    expected = custom_insert(array, add_idx, add_array)
+
+    np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.fast
+def test_batch_insert_preserves_padding_values():
+    array = jnp.array([[False], [False], [False], [True], [True], [True]])
+    add_array = jnp.zeros((3, 1), dtype=bool)
+    add_idx = jnp.array([1, 2, -1])
+
+    source_indices = get_insert_source_indices(array.shape[0], add_idx)
+    result = apply_insert(array, add_array, source_indices)
+    expected = custom_insert(array, add_idx, add_array)
+
+    np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "delidx",
+    [
+        [10000, 10000],
+        [2, 10000],
+        [1, 3, 10000],
+        [1, 2, 3],
+        [0, 7, 10000],
+    ],
+)
+def test_batch_delete_matches_custom_delete(delidx):
+    array = jnp.arange(40, dtype=float).reshape(8, 5)
+    delidx = jnp.asarray(delidx)
+
+    source_indices = get_delete_source_indices(array.shape[0], delidx)
+    result = compact_delete(array, source_indices)
+    expected = custom_delete(array, delidx)
+
+    np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.fast
+def test_build_add_theta_preserves_interval_order():
+    theta = jnp.concatenate(
+        [jnp.linspace(0, 2 * jnp.pi, 8)[:, None], jnp.full((4, 1), jnp.nan)]
+    )
+    idx = jnp.array([2, 5, 7, -1])
+    add_number = jnp.array([[2], [1], [3], [0]])
+
+    add_theta, add_idx = build_add_theta(
+        theta, idx, add_number, max_add=4, max_total_num=8
+    )
+
+    expected_theta = jnp.array(
+        [
+            theta[1, 0] + (theta[2, 0] - theta[1, 0]) / 3,
+            theta[1, 0] + 2 * (theta[2, 0] - theta[1, 0]) / 3,
+            theta[4, 0] + (theta[5, 0] - theta[4, 0]) / 2,
+            theta[6, 0] + (theta[7, 0] - theta[6, 0]) / 4,
+            theta[6, 0] + 2 * (theta[7, 0] - theta[6, 0]) / 4,
+            theta[6, 0] + 3 * (theta[7, 0] - theta[6, 0]) / 4,
+            jnp.nan,
+            jnp.nan,
+        ]
+    )
+
+    np.testing.assert_allclose(add_theta[:, 0], expected_theta, equal_nan=True)
+    np.testing.assert_array_equal(add_idx, [2, 2, 5, 7, 7, 7, -1, -1])


### PR DESCRIPTION
## Summary

  Refactor adaptive contour array updates while preserving the existing packed-array structure.

  - Generate new theta samples without repeated `scan` and `roll`.
  - Reuse shared gather indices when inserting or deleting contour state arrays.
  - Keep the legacy functions for behavior and performance comparison.
  - Add equivalence tests for insertion, deletion, and theta ordering.

  ## Results

  - Full test suite: `78 passed`
  - Magnification, gradients, sample counts, and exceed flags match the previous implementation.
  - Warm contour execution improves by approximately 6–7%.
  - Large-array deletion performance improves substantially.
  - Cold compilation time remains approximately unchanged.